### PR TITLE
フォントのパスを検索する問題の解決

### DIFF
--- a/lib/Miyako/API/font.rb
+++ b/lib/Miyako/API/font.rb
@@ -41,13 +41,8 @@ module Miyako
     # check font directory in gem directory
     base_pathes = []
     gpath = nil
-    searcher = Gem::GemPathSearcher.new
-    spec = searcher.find("miyako")
-    gpath = spec.full_gem_path if spec
-    if spec && gpath =~ /ruby\-miyako/
-      gpath = File.join(gpath,"lib","Miyako","fonts")
-      base_pathes << gpath if File.exist?(gpath)
-    end
+    gpath = File.absolute_path("#{File.dirname(__FILE__)}/../../fonts")
+    base_pathes << gpath if File.exist?(gpath)
 
     # check font directory in library(site_ruby) directory
     lpath = $LOAD_PATH.find{|path| File.exist?(File.join(path,"Miyako","fonts")) }

--- a/lib/Miyako/miyako.rb
+++ b/lib/Miyako/miyako.rb
@@ -81,7 +81,11 @@ module Miyako
     return VERSION
   end
 
-  osn = Config::CONFIG["target_os"].downcase
+  if RUBY_VERSION >= '1.9.3'
+    osn = RbConfig::CONFIG["target_os"].downcase
+  else
+    osn = Config::CONFIG["target_os"].downcase
+  end
   @@osName = "other"
   case osn
   when /mswin|mingw|cygwin|bccwin/


### PR DESCRIPTION
こんにちは。

Miyako を Mac で使おうと思い触っていたのですが、
フォントパスが通らない問題に直面しました。

スレッドでは以下のものとなります。

http://cyross.bbs.fc2.com/?act=reply&tid=7003169

こちらの問題に関して修正し、
ついでに deplicated だった Config::CONFIG を修正したパッチをお送りします。

私の方で利用している Ruby が ruby 1.9.3p194 (2012-04-20 revision 35410) [x86_64-darwin11.4.0] のため、
1.9.2 以前でも問題ないか？ という点に関してチェックが済んでおりません。

もし以前のバージョンに問題がありましたら、こちらの pull request はコンセプトとして確認頂いた上で、
マージせず reject して頂ければと思います。
